### PR TITLE
Tutoring services document

### DIFF
--- a/tutoring.md
+++ b/tutoring.md
@@ -18,7 +18,7 @@ To that end we offer a number of avenues for accessing tutoring services outside
 ### Open Tutoring
 Open Tutoring is our most available tutoring service and should likely be your first choice if you feel tutoring is necessary.
 
-Open Tutoring consists of a fixed set of hours during which experienced software developers are available at the Ada campus to answer questions and assist with debugging for any students present at that time.
+Open Tutoring consists of a fixed set of hours during which experienced software developers are available at the Ada campus to answer targetted questions and assist with debugging for any students present at that time.
 
 Due to the nature of Open Tutoring there aren't always enough Tutors for each student to receive one-on-one dedicated time through the entire session, however our Tutors attempt to make sure they work with every student at least once.
 
@@ -31,7 +31,7 @@ The current schedule for Open Tutoring is:
 (Last updated 2/23/2016 - Check your class Google calendar for temporary schedule changes.)
 
 ### Ad-hoc Tutoring
-Ad-hoc Tutoring is an ideal option when you feel that more dedicated one-on-one instruction is necessary, or you're unable to attend the Open Tutoring hours.
+Ad-hoc Tutoring is an ideal option when you feel that more dedicated one-on-one instruction is necessary, or you're unable to attend the Open Tutoring hours. Because you're working individually with your tutor it's also possible to go beyond assistance with a particular project hurlde and get more in-depth on programming concepts.
 
 Ad-hoc Tutoring consists of one-time, individual tutoring sessions arranged through the [ada-tutors mailing list](mailto:ada-tutors@googlegroups.com). The mailing list has many volunteers from the tech industry in Seattle including a number of Adies from previous cohorts.
 

--- a/tutoring.md
+++ b/tutoring.md
@@ -33,7 +33,7 @@ The current schedule for Open Tutoring is:
 ### Ad-hoc Tutoring
 Ad-hoc Tutoring is an ideal option when you feel that more dedicated 1-on-1 instruction is necessary, or you're unable to attend the Open Tutoring hours.
 
-Ad-hoc Tutoring consists of one-time, individual tutoring sessions arranged through our mailing list (the `ada-tutors` Google group). The mailing list has many volunteers from the tech industry in Seattle including a number of Adies from previous cohorts.
+Ad-hoc Tutoring consists of one-time, individual tutoring sessions arranged through the [ada-tutors mailing list](mailto:ada-tutors@googlegroups.com). The mailing list has many volunteers from the tech industry in Seattle including a number of Adies from previous cohorts.
 
 When you post a message to the mailing list please include the following information to help our tutors figure out if they would be a good fit for working with you:
 - Where you are at in the curriculum, including what project you're working on if your tutoring request relates to a specific project

--- a/tutoring.md
+++ b/tutoring.md
@@ -5,14 +5,14 @@
 1. [Services](#services)
   1. [Open Tutoring](#open-tutoring)
   1. [Ad-hoc Tutoring](#ad-hoc-tutoring)
-  1. [Secheduled Tutoring](#scheduled-tutoring)
+  1. [Scheduled Tutoring](#scheduled-tutoring)
 1. [FAQ](#faq)
   1. [Which tutoring service should I use?](#which-tutoring-service-should-i-use)
 
 ## Overview
 Ada Developers Academy is committed to ensuring that all of our students receive the support they need to succeed with our curriculum and go on to become professional software developers.
 
-To that end we offer a number avenues for accessing tutoring services outside of class hours. This document explains the different tutoring services offered including when and where they are available and has a FAQ for guiding you through the process of selecting an appropriate tutoring service.
+To that end we offer a number of avenues for accessing tutoring services outside of class hours. This document explains the different tutoring services offered including when and where they are available and has a FAQ for guiding you through the process of selecting an appropriate tutoring service.
 
 ## Services
 ### Open Tutoring
@@ -33,7 +33,7 @@ The current schedule for Open Tutoring is:
 ### Ad-hoc Tutoring
 Ad-hoc Tutoring is an ideal option when you feel that more dedicated 1-on-1 instruction is necessary, or you're unable to attend the Open Tutoring hours.
 
-Ad-hoc Tutoring consists of one-time, individual tutoring sessions arranged through our mailing list (the `ada-tutors` Google group). The mailing list has many volunteers from the tech industry in Seattle, including a number of Adies from previous cohorts.
+Ad-hoc Tutoring consists of one-time, individual tutoring sessions arranged through our mailing list (the `ada-tutors` Google group). The mailing list has many volunteers from the tech industry in Seattle including a number of Adies from previous cohorts.
 
 When you post a message to the mailing list please include the following information to help our tutors figure out if they would be a good fit for working with you:
 - Where you are at in the curriculum, including what project you're working on if your tutoring request relates to a specific project

--- a/tutoring.md
+++ b/tutoring.md
@@ -44,9 +44,9 @@ When you send an email to the mailing list please include the following informat
 Once you've sent an email to the mailing list an Ada staff member will follow up with you within a few days to make sure that you were able to find assistance or help to make other arrangements.
 
 ### Scheduled Tutoring
-Scheduled Tutoring is generally reserved for students who have need of recurrent, dedicated instruction outside of class such as when significant instruction material has been missed due to absences.
+Scheduled Tutoring is limited in availability and reserved for students who instructors identify as most likely to benefit from additional 1-on-1 time to solidify concepts.
 
-Because our resources for this service are more limited than the other services, Scheduled Tutoring must be arranged with the approval of Ada staff. If you feel that the above situation applies to you, please reach out to your instructor to discuss the possibility of setting up Scheduled Tutoring.
+Because our resources for this service are more limited, Scheduled Tutoring must be arranged with the approval of Ada staff. If you feel that the above situation applies to you, please reach out to your instructor to discuss the possibility of setting up Scheduled Tutoring.
 
 Scheduled Tutoring involves agreed-upon Areas of Focus and associated goals which will be evaluated at the completion of the tutoring schedule to determine if it was successful or if additional tutoring may be needed. Tutoring schedules are generally for 2-3 weeks with 1 or 2 sessions per week, as determined by Ada staff.
 

--- a/tutoring.md
+++ b/tutoring.md
@@ -1,0 +1,57 @@
+# Ada's Tutoring Services
+
+## Table of Contents
+1. [Overview](#overview)
+1. [Services](#services)
+  1. [Open Tutoring](#open-tutoring)
+  1. [Ad-hoc Tutoring](#ad-hoc-tutoring)
+  1. [Secheduled Tutoring](#scheduled-tutoring)
+1. [FAQ](#faq)
+  1. [Which tutoring service should I use?](#which-tutoring-service-should-i-use)
+
+## Overview
+Ada Developers Academy is committed to ensuring that all of our students receive the support they need to succeed with our curriculum and go on to become professional software developers.
+
+To that end we offer a number avenues for accessing tutoring services outside of class hours. This document explains the different tutoring services offered including when and where they are available and has a FAQ for guiding you through the process of selecting an appropriate tutoring service.
+
+## Services
+### Open Tutoring
+Open Tutoring is our most available tutoring service and should likely be your first choice if you feel tutoring is necessary.
+
+Open Tutoring consists of a fixed set of hours during which experienced software developers are available at the Ada campus to answer questions and assist with debugging for any students present at that time.
+
+Due to the nature of Open Tutoring there aren't always enough Tutors for each student to receive 1-on-1 dedicated time through the entire session, however our Tutors attempt to make sure they work with every student at least once.
+
+The current schedule for Open Tutoring is:
+
+| Monday | Tuesday | Wednesday | Thursday | Friday | Saturday | Sunday |
+|:------:|:-------:|:---------:|:--------:|:------:|:--------:|:------:|
+|        | 5-7 PM  |           | 5-7 PM   |        | 11 - 2PM |        |
+
+(Last updated 2/23/2016 - Check your class Google calendar for temporary schedule changes.)
+
+### Ad-hoc Tutoring
+Ad-hoc Tutoring is an ideal option when you feel that more dedicated 1-on-1 instruction is necessary, or you're unable to attend the Open Tutoring hours.
+
+Ad-hoc Tutoring consists of one-time, individual tutoring sessions arranged through our mailing list (the `ada-tutors` Google group). The mailing list has many volunteers from the tech industry in Seattle, including a number of Adies from previous cohorts.
+
+When you post a message to the mailing list please include the following information to help our tutors figure out if they would be a good fit for working with you:
+- Where you are at in the curriculum, including what project you're working on if your tutoring request relates to a specific project
+- What particular technologies you're working with (Ruby, Rails, JavaScript, Backbone, etc.)
+- What times would work best for you
+- Something about yourself and/or your preferred learning and communication styles
+
+Once you've posted a message to the mailing list an Ada staff member will follow up with you within a few days to make sure that you were able to find assistance or help to make other arrangements.
+
+### Scheduled Tutoring
+Scheduled Tutoring is generally reserved for students who have need of recurrent, dedicated instruction outside of class such as when significant instruction material has been missed due to absences.
+
+Because our resources for this service are more limited than the other services, Scheduled Tutoring must be arranged with the approval of Ada staff. If you feel that the above situation applies to you, please reach out to your instructor to discuss the possibility of setting up Scheduled Tutoring.
+
+Scheduled Tutoring involves agreed-upon Areas of Focus and associated goals which will be evaluated at the completion of the tutoring schedule to determine if it was successful or if additional tutoring may be needed. Tutoring schedules are generally for 2-3 weeks with 1 or 2 sessions per week, as determined by Ada staff.
+
+## FAQ
+### Which tutoring service should I use?
+Because of the differing availability of tutoring services we strongly advise that all students interested in tutoring first attend Open Tutoring or, if that is not possible, request dedicated Ad-hoc Tutoring through the mailing list.
+
+If both of those options are not available or are unsuccessful we suggest that you speak with one of your instructors and a more individual tutoring plan can be devised.

--- a/tutoring.md
+++ b/tutoring.md
@@ -8,6 +8,7 @@
   1. [Scheduled Tutoring](#scheduled-tutoring)
 1. [FAQ](#faq)
   1. [Which tutoring service should I use?](#which-tutoring-service-should-i-use)
+  1. [How can I best prepare for tutoring?](#how-can-i-best-prepare-for-tutoring)
 
 ## Overview
 Ada Developers Academy is committed to ensuring that all of our students receive the support they need to succeed with our curriculum and go on to become professional software developers.
@@ -55,3 +56,19 @@ Scheduled Tutoring involves agreed-upon Areas of Focus and associated goals whic
 Because of the differing availability of tutoring services we strongly advise that all students interested in tutoring first attend Open Tutoring or, if that is not possible, request dedicated Ad-hoc Tutoring through the mailing list.
 
 If both of those options are not available or are unsuccessful we suggest that you speak with one of your instructors and a more individual tutoring plan can be devised.
+
+### How can I best prepare for tutoring?
+#### Open Tutoring
+For Open Tutoring the best way to be prepared is to have a specific problem in mind when approaching a tutor. Try to figure out as much as possible about the error message or buggy behavior you're seeing, first.
+
+Have a list of things that you've searched for on Google / Stack Overflow, including things that you've tried which didn't seem to work. Having all of this information handy when you work with a tutor will make it easier for you to give them the necessary to context to help you figure out how to proceed.
+
+#### Ad-hoc Tutoring
+For Ad-hoc Tutoring you should have a couple of questions in mind, either problems you're having with a particular project or general questions about a technology or concept where you've repeatedly had issues (e.g. "How does routing work in Ruby on Rails?").
+
+Make sure to include some context about these questions when contacting the mailing list, however you do not need to go into the complete details within your email. When arriving for the meeting that you've scheduled be sure to have your project code available and, if possible, be able to run it to display any error messages / bugs.
+
+#### Scheduled Tutoring
+Because Scheduled Tutoring involves a pre-defined set of focus areas and goals you should prepare for each session by reviewing them. If any class work or projects since your last session apply to the focus areas, plan to talk about any difficulties or successes you've had with that work.
+
+In most cases your tutor will not be an Ada staff member so it would be helpful to make sure they have context for where you are at in the curriculum. You should reach out to them via email before each session and send them links to the repository for your current project and to your (or your group's) specific fork. If they've had time to review what you've been working on since the last session it will make your tutoring time more productive.

--- a/tutoring.md
+++ b/tutoring.md
@@ -20,7 +20,7 @@ Open Tutoring is our most available tutoring service and should likely be your f
 
 Open Tutoring consists of a fixed set of hours during which experienced software developers are available at the Ada campus to answer questions and assist with debugging for any students present at that time.
 
-Due to the nature of Open Tutoring there aren't always enough Tutors for each student to receive 1-on-1 dedicated time through the entire session, however our Tutors attempt to make sure they work with every student at least once.
+Due to the nature of Open Tutoring there aren't always enough Tutors for each student to receive one-on-one dedicated time through the entire session, however our Tutors attempt to make sure they work with every student at least once.
 
 The current schedule for Open Tutoring is:
 
@@ -31,7 +31,7 @@ The current schedule for Open Tutoring is:
 (Last updated 2/23/2016 - Check your class Google calendar for temporary schedule changes.)
 
 ### Ad-hoc Tutoring
-Ad-hoc Tutoring is an ideal option when you feel that more dedicated 1-on-1 instruction is necessary, or you're unable to attend the Open Tutoring hours.
+Ad-hoc Tutoring is an ideal option when you feel that more dedicated one-on-one instruction is necessary, or you're unable to attend the Open Tutoring hours.
 
 Ad-hoc Tutoring consists of one-time, individual tutoring sessions arranged through the [ada-tutors mailing list](mailto:ada-tutors@googlegroups.com). The mailing list has many volunteers from the tech industry in Seattle including a number of Adies from previous cohorts.
 
@@ -44,7 +44,7 @@ When you send an email to the mailing list please include the following informat
 Once you've sent an email to the mailing list an Ada staff member will follow up with you within a few days to make sure that you were able to find assistance or help to make other arrangements.
 
 ### Scheduled Tutoring
-Scheduled Tutoring is limited in availability and reserved for students who instructors identify as most likely to benefit from additional 1-on-1 time to solidify concepts.
+Scheduled Tutoring is limited in availability and reserved for students who instructors identify as most likely to benefit from additional one-on-one time to solidify concepts.
 
 Because our resources for this service are more limited, Scheduled Tutoring must be arranged with the approval of Ada staff. If you feel that the above situation applies to you, please reach out to your instructor to discuss the possibility of setting up Scheduled Tutoring.
 

--- a/tutoring.md
+++ b/tutoring.md
@@ -35,13 +35,13 @@ Ad-hoc Tutoring is an ideal option when you feel that more dedicated 1-on-1 inst
 
 Ad-hoc Tutoring consists of one-time, individual tutoring sessions arranged through the [ada-tutors mailing list](mailto:ada-tutors@googlegroups.com). The mailing list has many volunteers from the tech industry in Seattle including a number of Adies from previous cohorts.
 
-When you post a message to the mailing list please include the following information to help our tutors figure out if they would be a good fit for working with you:
+When you send an email to the mailing list please include the following information to help our tutors figure out if they would be a good fit for working with you:
 - Where you are at in the curriculum, including what project you're working on if your tutoring request relates to a specific project
 - What particular technologies you're working with (Ruby, Rails, JavaScript, Backbone, etc.)
 - What times would work best for you
 - Something about yourself and/or your preferred learning and communication styles
 
-Once you've posted a message to the mailing list an Ada staff member will follow up with you within a few days to make sure that you were able to find assistance or help to make other arrangements.
+Once you've sent an email to the mailing list an Ada staff member will follow up with you within a few days to make sure that you were able to find assistance or help to make other arrangements.
 
 ### Scheduled Tutoring
 Scheduled Tutoring is generally reserved for students who have need of recurrent, dedicated instruction outside of class such as when significant instruction material has been missed due to absences.


### PR DESCRIPTION
This is the document that we discussed creating at the instructional staff meeting on 2/22.

I tried to make clear the differences in our tutoring services, especially in how easy it would be to get tutoring through one service versus another. I chose the term Ad-hoc Tutoring for when students arrange tutoring themselves through the mailing list, let me know if you have a better term for that!

I also included a short FAQ item that lays out very explicitly that students should first try Open Tutoring and Ad-hoc Tutoring before talking with their instructor about setting up Scheduled Tutoring.