### PR TITLE
CS Fundamentals Schedule to Pedagogy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Pedagogy
 
 This repository is all about the way we teach! Here you'll find things like our syllabus, information on weekly learning goals and how we structure projects.
+
+- [Syllabus](syllabus.md)
+  - [Tutoring](tutoring.md)
+  - [Ada Rule of Three](rule-of-three.md)
+  - [Homework Labels](hw-learning-goal-label-key.md)
+- CS Fundamentals
+  - [Classroom](cs-fundamentals-classroom.md)
+  - [Internship](cs-fundamentals-internships.md)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository is all about the way we teach! Here you'll find things like our syllabus, information on weekly learning goals and how we structure projects.
 
-- [Syllabus](syllabus.md)
+- [Ada Classroom Syllabus](syllabus.md)
   - [Tutoring](tutoring.md)
   - [Ada Rule of Three](rule-of-three.md)
   - [Homework Labels](hw-learning-goal-label-key.md)

--- a/cs-fundamentals-classroom.md
+++ b/cs-fundamentals-classroom.md
@@ -1,24 +1,24 @@
 # CS Fundamentals Schedule - Classroom Portion
 
-| Week    | Unit
-|---------|------------------
-| Week 01 | Imposter Syndrome, Deep work
-| Week 02 | Caucus/Workshop
-| Week 03 | [Binary & Memory](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Binary.md)
-| Week 04 | Caucus/Workshop
-| Week 05 | [Arrays](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Arrays.md) and [Algorithmic Efficiency](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Efficiency%20of%20algorithms.md)
-| Week 06 | [Arrays](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Arrays.md) continued, [Introduction to Data Structures](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Data%20Structures.md)
-| Week 07 | [Introduction to Data Structures](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Data%20Structures.md)
-| Week 08 | _BREAK_
-| Week 09 | [Understanding function calls](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Understanding%20function%20calls.md)
-| Week 10 | [Solving problems using Hash tables](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/hash-tables.md)
-| Week 11 | Caucus/Workshop
-| Week 12 | [Whiteboarding tips](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Whiteboarding-Tips.md)
-| Week 13 | [Instructors get interviewed, White boarding practice](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Whiteboarding-Tips.md)
-| Week 14 | [Linked Lists Part 1](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Linked%20Lists.md)
-| Week 15 | [Introduction to Recursion](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Recursion.md)
-| Week 16 | [Recursion](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Recursion.md) continued, [Merge Sort](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Sorting.md)
-| Week 17 | [Interview preparation](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Whiteboarding-Tips.md)
-| Week 18 | _INTERVIEWS_
-| Week 19 | Caucus/Workshop
-| Week 20 | [Introduction to Software Design](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Software%20Design.md)
+| Week    | Date | Unit
+|---------|---------|------------------
+| Week 01 |  8/8/2019 | Imposter Syndrome, Deep work
+| Week 02 |  8/15/2019 | Caucus/Workshop
+| Week 03 | 8/22/2019 | [Binary & Memory](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Binary.md)
+| Week 04 | 8/29/2019 | Caucus/Workshop
+| Week 05 | 9/5/2019 | [Arrays](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Arrays.md) and [Algorithmic Efficiency](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Efficiency%20of%20algorithms.md)
+| Week 06 | 9/12/2019 | [Arrays](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Arrays.md) continued, [Introduction to Data Structures](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Data%20Structures.md)
+| Week 07 | 9/19/2019 | [Introduction to Data Structures](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Data%20Structures.md)
+| Week 08 | | _BREAK_
+| Week 09 | 10/3/2019 | [Understanding function calls](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Understanding%20function%20calls.md)
+| Week 10 | 10/10/2019 | [Solving problems using Hash tables](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/hash-tables.md)
+| Week 11 | 10/17/2019 | Caucus/Workshop
+| Week 12 | 10/24/2019 | [Whiteboarding tips](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Whiteboarding-Tips.md)
+| Week 13 | 10/31/2019 | [Instructors get interviewed, White boarding practice](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Whiteboarding-Tips.md)
+| Week 14 | 11/7/2019 | [Linked Lists Part 1](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Linked%20Lists.md)
+| Week 15 | 11/14/2019 | [Introduction to Recursion](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Recursion.md)
+| Week 16 | 11/21/2019 | [Recursion](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Recursion.md) continued, [Merge Sort](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Sorting.md)
+| Week 17 | 11/28/2019 | [Interview preparation](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Whiteboarding-Tips.md)
+| Week 18 | | _INTERVIEWS_
+| Week 19 | 12/12/2019 | Caucus/Workshop
+| Week 20 | 12/19/2019 | [Introduction to Software Design](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Software%20Design.md)

--- a/cs-fundamentals-classroom.md
+++ b/cs-fundamentals-classroom.md
@@ -1,0 +1,24 @@
+# CS Fundamentals Schedule - Classroom Portion
+
+| Week    | Unit
+|---------|------------------
+| Week 01 | Imposter Syndrome, Deep work
+| Week 02 | Caucus/Workshop
+| Week 03 | [Binary & Memory](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Binary.md)
+| Week 04 | Caucus/Workshop
+| Week 05 | [Arrays](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Arrays.md) and [Algorithmic Efficiency](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Efficiency%20of%20algorithms.md)
+| Week 06 | [Arrays](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Arrays.md) continued, [Introduction to Data Structures](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Data%20Structures.md)
+| Week 07 | [Introduction to Data Structures](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Data%20Structures.md)
+| Week 08 | _BREAK_
+| Week 09 | [Understanding function calls](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Understanding%20function%20calls.md)
+| Week 10 | [Solving problems using Hash tables](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/hash-tables.md)
+| Week 11 | Caucus/Workshop
+| Week 12 | [Whiteboarding tips](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Whiteboarding-Tips.md)
+| Week 13 | [Instructors get interviewed, White boarding practice](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Whiteboarding-Tips.md)
+| Week 14 | [Linked Lists Part 1](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Linked%20Lists.md)
+| Week 15 | [Introduction to Recursion](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Recursion.md)
+| Week 16 | [Recursion](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Introduction%20to%20Recursion.md) continued, [Merge Sort](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Sorting.md)
+| Week 17 | [Interview preparation](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Whiteboarding-Tips.md)
+| Week 18 | _INTERVIEWS_
+| Week 19 | Caucus/Workshop
+| Week 20 | [Introduction to Software Design](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/classroom/Software%20Design.md)

--- a/cs-fundamentals-internships.md
+++ b/cs-fundamentals-internships.md
@@ -1,0 +1,23 @@
+# CS Fundamentals Schedule - Internships
+
+| Week    | Date | Unit
+|---------|---------|------------------
+| Week 00 |  8/8/2019 | Break Week!
+| Week 01 |  8/15/2019 | [Code Reviews](https://docs.google.com/presentation/d/1vZz0JtIspH2N4v59KymKTYHJ5xxOMKOe/edit#slide=id.p1) & [Linked Lists](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/internship/linked_lists.md)
+| Week 03 | 8/22/2019 | [Linked Lists](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/internship/linked_lists.md) & [Binary Search Trees](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/internship/Binary%20Search%20Trees.md)
+| Week 04 | 8/29/2019 |  Internships Expectations Panel
+| Week 05 | 9/5/2019 | [Binary Search Trees](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/internship/Binary%20Search%20Trees.md) & [Stacks & Queues](https://github.com/Ada-Developers-Academy/textbook-curriculum/tree/master/04-cs-fundamentals/internship/stacks_and_queues)
+| Week 06 | 9/12/2019 | [Stacks & Queues](https://github.com/Ada-Developers-Academy/textbook-curriculum/tree/master/04-cs-fundamentals/internship/stacks_and_queues) & [Hash Tables](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/internship/Hash%20Tables.md)
+| Week 07 | 9/19/2019 | [Stacks & Queues](https://github.com/Ada-Developers-Academy/textbook-curriculum/tree/master/04-cs-fundamentals/internship/stacks_and_queues) & [Binary Search Trees](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/internship/Binary%20Search%20Trees.md)
+| Week 08 | | _BREAK_
+| Week 09 | 10/3/2019 | [Binary Search Trees](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/internship/Binary%20Search%20Trees.md) & [Algorithms](https://github.com/Ada-Developers-Academy/textbook-curriculum/blob/master/04-cs-fundamentals/internship/Introduction%20to%20Algorithms.md)
+| Week 10 | 10/10/2019 | CS Fun [Graphs](https://drive.google.com/open?id=1RXNXuQjH8I76OcJaua5TTUMlbJ9l5kcX) & Get with Manager about mid-point review, Cacus with Sarah 3:00pm -5:00pm
+| Week 11 | 10/17/2019 | CS Fun Graphs continued](https://drive.google.com/open?id=1RXNXuQjH8I76OcJaua5TTUMlbJ9l5kcX) &  Recruiter/Hiring Manager Panel Discussion
+| Week 12 | 10/24/2019 | Recruiting Tool Box Job prep
+| Week 13 | 10/31/2019 | Technical Whiteboarding, What to expect, deep dive with Steve
+| Week 14 | 11/7/2019 | Mock Interviews  & Recruiters @ Ada
+| Week 15 | 11/14/2019 | Mock Interviews continued
+| Week 16 | 11/21/2019 | Mock Interviews continued
+| Week 17 | 11/28/2019 | Level Set Offer Expectations with Alums / Dissecting An offer with Blaine
+| Week 18 | | _Interview Week C12_
+| Week 19 | 12/12/2019 | Fulltime Interview Loops


### PR DESCRIPTION
Update to move CS Fundamentals schedule from the Daily Curriculum repo and into Pedagogy to be alongside the classroom syllabus weekly schedule. 